### PR TITLE
fixes the tab bar on iphone-x

### DIFF
--- a/src/ios/CDVTabBar.m
+++ b/src/ios/CDVTabBar.m
@@ -16,6 +16,11 @@
 #import "CDVTabBar.h"
 
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+#define IS_IPHONE (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone)
+#define SCREEN_WIDTH ([[UIScreen mainScreen] bounds].size.width)
+#define SCREEN_HEIGHT ([[UIScreen mainScreen] bounds].size.height)
+#define SCREEN_MAX_LENGTH (MAX(SCREEN_WIDTH, SCREEN_HEIGHT))
+#define IS_IPHONE_X  (IS_IPHONE && SCREEN_MAX_LENGTH == 812.0)
 
 @implementation CDVTabBar
 #ifndef __IPHONE_3_0
@@ -131,6 +136,11 @@
     CGRect tabBarBounds;
     if ( SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
       //webViewBounds.origin.y += 20;
+    }
+
+    if (IS_IPHONE_X) {
+        webViewBounds.origin.y += 15;
+        height = 90.0f;
     }
 
   NSNotification* notif = [NSNotification notificationWithName:@"CDVLayoutSubviewAdded" object:tabBar];


### PR DESCRIPTION
Currently, the icons and text are scrunched together on the iPhone X.

The fix checks the screen length and if the screen length is `812.0f` the correct sizing on the tab bar is applied.

